### PR TITLE
Implementing Custom Fonts in Website Design

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,15 @@
       name="description"
       content="Web site created using create-react-app"
     />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Open+Sans&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fredoka&display=swap"
+      rel="stylesheet"
+    />
+
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/images/logo.jpg" />
     <link rel="manifest" href="%PUBLIC_URL%/images/logo.jpg" />
     <title>Npm Start</title>

--- a/src/index.css
+++ b/src/index.css
@@ -1,10 +1,17 @@
+:root {
+  --font-primary: 'Open Sans', sans-serif;
+  --font-secondary: 'Fredoka', sans-serif;
+}
+
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: var(--font-primary);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+.secondary-font {
+  font-family: var(--font-secondary);
 }
 
 code {

--- a/src/utils/style/ThemeColors.js
+++ b/src/utils/style/ThemeColors.js
@@ -23,6 +23,10 @@ const theme = createTheme({
         background: {
             default: '#181818',
         },
+        typography: {
+            fontFamily: '\'Open Sans\', sans-serif',
+            secondaryFont: '\'Fredoka\', sans-serif', 
+        },
     },
 });
 


### PR DESCRIPTION
1. Add the Open Sans font to the website using the link provided: https://fonts.google.com/specimen/Open+Sans?query=Op. Define this font as the primary font for our site.

2. Incorporate the Fredoka font into the website using the link provided: https://fonts.google.com/specimen/Fredoka. Specify this font as the secondary font for our site.

3. Ensure that both fonts are added globally to the website by defining them in an object named 'theme' within the system. This object should contain the font families for Open Sans and Fredoka.

Issues #13 